### PR TITLE
Add .root() method for getting an iterator to the root object instead of end()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if (NOT TARGET nonstd::string_view-lite)
     add_subdirectory(external/string-view-lite)
 endif ()
 
-add_compile_options(-Wall -Wextra -Werror -pedantic)
+add_compile_options(-Wall -Wextra -Werror)
 
 add_subdirectory(src)
 

--- a/include/jsonbuilder/JsonBuilder.h
+++ b/include/jsonbuilder/JsonBuilder.h
@@ -68,7 +68,6 @@ Error handling:
 #include <nonstd/string_view.hpp>
 #include <uuid/uuid.h>
 
-
 namespace jsonbuilder {
 struct UuidStruct
 {
@@ -543,6 +542,7 @@ class JsonValue : private JsonValueBase
     
 
 
+
     Note that methods in this class must never return a hidden node -- they
     must return the first non-hidden node after the node they might have
     otherwise returned. Because the external interface abstracts these hidden
@@ -804,7 +804,7 @@ All other values are leaf nodes in the tree and can store arbitrary data.
 
 The root of the tree is an Object. This object is implicit -- it is always
 present and need not be added by the user. In methods that accept a "parent
-iterator" parameter, use the end() iterator to refer to the root of the tree.
+iterator" parameter, use the root() iterator to refer to the root of the tree.
 */
 class JsonBuilder
 {
@@ -915,6 +915,10 @@ class JsonBuilder
     const_iterator end() const throw();
     const_iterator cend() const throw();
 
+    iterator root() throw();
+    const_iterator root() const throw();
+    const_iterator croot() const throw();
+
     /*
     Returns a pointer to the first element in the backing raw data vector.
     */
@@ -1008,8 +1012,9 @@ class JsonBuilder
     O(n), where n is the total number of children at each level.
     */
     template<class... NameTys>
-    iterator
-    find(nonstd::string_view const& firstName, NameTys const&... additionalNames) throw()
+    iterator find(
+        nonstd::string_view const& firstName,
+        NameTys const&... additionalNames) throw()
     {
         return iterator(
             const_iterator(this, Find(0, firstName, additionalNames...)));
@@ -1536,7 +1541,7 @@ class JsonImplementType
             JsonBuilder& builder,                                         \
             bool front,                                                   \
             JsonConstIterator const& itParent,                            \
-            nonstd::string_view const& name,                                 \
+            nonstd::string_view const& name,                              \
             T const& data);                                               \
     }
 
@@ -1549,7 +1554,7 @@ class JsonImplementType
             JsonBuilder& builder,                  \
             bool front,                            \
             JsonConstIterator const& itParent,     \
-            nonstd::string_view const& name,          \
+            nonstd::string_view const& name,       \
             T const& data);                        \
     }
 

--- a/include/jsonbuilder/JsonBuilder.h
+++ b/include/jsonbuilder/JsonBuilder.h
@@ -539,9 +539,6 @@ class JsonValue : private JsonValueBase
     so begin(), begin(itParent), end(itParent), and operator++ operations can
     potentially become O(N) if there are a large number of erased or childless
     nodes.
-    
-
-
 
     Note that methods in this class must never return a hidden node -- they
     must return the first non-hidden node after the node they might have

--- a/src/JsonBuilder.cpp
+++ b/src/JsonBuilder.cpp
@@ -930,12 +930,11 @@ and i32) aren't perfectly optimal... But they're probably close enough.
     }
 
 #define IMPLEMENT_JsonImplementType(DataType, ValueType)          \
-    IMPLEMENT_AddValue(DataType, sizeof(data), &data, ValueType)  \
-        IMPLEMENT_GetUnchecked(DataType, ValueType)               \
+    IMPLEMENT_AddValue(DataType, sizeof(data), &data, ValueType); \
+    IMPLEMENT_GetUnchecked(DataType, ValueType);                  \
                                                                   \
-            bool                                                  \
-            JsonImplementType<DataType>::ConvertTo(               \
-                JsonValue const& value, DataType& result) throw() \
+    bool JsonImplementType<DataType>::ConvertTo(                  \
+        JsonValue const& value, DataType& result) throw()         \
     {                                                             \
         return ConvertTo##ValueType(value, result);               \
     }
@@ -981,13 +980,13 @@ bool JsonImplementType<bool>::ConvertTo(JsonValue const& value, bool& result) th
     return success;
 }
 
-IMPLEMENT_AddValue(bool, sizeof(data), &data, JsonBool)
+IMPLEMENT_AddValue(bool, sizeof(data), &data, JsonBool);
 
-    // JsonUInt
+// JsonUInt
 
-    bool JsonImplementType<unsigned long long>::ConvertTo(
-        JsonValue const& value,
-        unsigned long long& result) throw()
+bool JsonImplementType<unsigned long long>::ConvertTo(
+    JsonValue const& value,
+    unsigned long long& result) throw()
 {
     static double const UnsignedHuge = 18446744073709551616.0;
 
@@ -1061,11 +1060,11 @@ static uint64_t GetUncheckedJsonUInt(JsonValue const& value)
     return result;
 }
 
-IMPLEMENT_AddValue(unsigned long long, sizeof(data), &data, JsonUInt)
-    IMPLEMENT_GetUnchecked(unsigned long long, JsonUInt)
+IMPLEMENT_AddValue(unsigned long long, sizeof(data), &data, JsonUInt);
+IMPLEMENT_GetUnchecked(unsigned long long, JsonUInt);
 
-        template<class T>
-        static bool ConvertToJsonUInt(JsonValue const& value, T& result)
+template<class T>
+static bool ConvertToJsonUInt(JsonValue const& value, T& result)
 {
     unsigned long long implResult;
     bool success;
@@ -1083,16 +1082,16 @@ IMPLEMENT_AddValue(unsigned long long, sizeof(data), &data, JsonUInt)
     return success;
 }
 
-IMPLEMENT_JsonImplementType(unsigned char, JsonUInt)
-    IMPLEMENT_JsonImplementType(unsigned short, JsonUInt)
-        IMPLEMENT_JsonImplementType(unsigned int, JsonUInt)
-            IMPLEMENT_JsonImplementType(unsigned long, JsonUInt)
+IMPLEMENT_JsonImplementType(unsigned char, JsonUInt);
+IMPLEMENT_JsonImplementType(unsigned short, JsonUInt);
+IMPLEMENT_JsonImplementType(unsigned int, JsonUInt);
+IMPLEMENT_JsonImplementType(unsigned long, JsonUInt);
 
-    // JsonInt
+// JsonInt
 
-    bool JsonImplementType<signed long long>::ConvertTo(
-        JsonValue const& value,
-        signed long long& result) throw()
+bool JsonImplementType<signed long long>::ConvertTo(
+    JsonValue const& value,
+    signed long long& result) throw()
 {
     static double const SignedHuge = 9223372036854775808.0;
 
@@ -1166,11 +1165,11 @@ static int64_t GetUncheckedJsonInt(JsonValue const& value)
     return result;
 }
 
-IMPLEMENT_AddValue(signed long long, sizeof(data), &data, JsonInt)
-    IMPLEMENT_GetUnchecked(signed long long, JsonInt)
+IMPLEMENT_AddValue(signed long long, sizeof(data), &data, JsonInt);
+IMPLEMENT_GetUnchecked(signed long long, JsonInt);
 
-        template<class T>
-        static bool ConvertToJsonInt(JsonValue const& value, T& result)
+template<class T>
+static bool ConvertToJsonInt(JsonValue const& value, T& result)
 {
     signed long long implResult;
     bool success;
@@ -1191,14 +1190,14 @@ IMPLEMENT_AddValue(signed long long, sizeof(data), &data, JsonInt)
     return success;
 }
 
-IMPLEMENT_JsonImplementType(signed char, JsonInt)
-    IMPLEMENT_JsonImplementType(signed short, JsonInt)
-        IMPLEMENT_JsonImplementType(signed int, JsonInt)
-            IMPLEMENT_JsonImplementType(signed long, JsonInt)
+IMPLEMENT_JsonImplementType(signed char, JsonInt);
+IMPLEMENT_JsonImplementType(signed short, JsonInt);
+IMPLEMENT_JsonImplementType(signed int, JsonInt);
+IMPLEMENT_JsonImplementType(signed long, JsonInt);
 
-    // JsonFloat
+// JsonFloat
 
-    double JsonImplementType<double>::GetUnchecked(JsonValue const& value) throw()
+double JsonImplementType<double>::GetUnchecked(JsonValue const& value) throw()
 {
     assert(value.Type() == JsonFloat);
     double result;
@@ -1254,13 +1253,13 @@ bool JsonImplementType<double>::ConvertTo(
     return success;
 }
 
-IMPLEMENT_AddValue(double, sizeof(data), &data, JsonFloat)
+IMPLEMENT_AddValue(double, sizeof(data), &data, JsonFloat);
 
 #define GetUncheckedJsonFloat(value) \
     JsonImplementType<double>::GetUnchecked(value)
 
-    template<class T>
-    static bool ConvertToJsonFloat(JsonValue const& value, T& result)
+template<class T>
+static bool ConvertToJsonFloat(JsonValue const& value, T& result)
 {
     double implResult;
     bool success = JsonImplementType<double>::ConvertTo(value, implResult);
@@ -1268,26 +1267,26 @@ IMPLEMENT_AddValue(double, sizeof(data), &data, JsonFloat)
     return success;
 }
 
-IMPLEMENT_JsonImplementType(float, JsonFloat)
+IMPLEMENT_JsonImplementType(float, JsonFloat);
 
-    // JsonUtf8
+// JsonUtf8
 
-    JsonIterator JsonImplementType<char*>::AddValue(
-        JsonBuilder& builder,
-        bool front,
-        JsonConstIterator const& itParent,
-        nonstd::string_view const& name,
-        char const* psz)
+JsonIterator JsonImplementType<char*>::AddValue(
+    JsonBuilder& builder,
+    bool front,
+    JsonConstIterator const& itParent,
+    nonstd::string_view const& name,
+    char const* psz)
 {
     return builder.AddValue(
         front, itParent, name, JsonUtf8, static_cast<unsigned>(strlen(psz)), psz);
 }
 
-IMPLEMENT_AddValue(char, sizeof(data), &data, JsonUtf8)
-    IMPLEMENT_AddValue(std::string, data.size(), data.data(), JsonUtf8)
+IMPLEMENT_AddValue(char, sizeof(data), &data, JsonUtf8);
+IMPLEMENT_AddValue(std::string, data.size(), data.data(), JsonUtf8);
 
-        nonstd::string_view JsonImplementType<nonstd::string_view>::GetUnchecked(
-            JsonValue const& value) throw()
+nonstd::string_view
+JsonImplementType<nonstd::string_view>::GetUnchecked(JsonValue const& value) throw()
 {
     assert(value.Type() == JsonUtf8);
     unsigned cb;
@@ -1389,11 +1388,11 @@ JsonImplementType<std::chrono::system_clock::time_point>::GetUnchecked(
 
 // JsonUuid
 
-IMPLEMENT_AddValue(UuidStruct, sizeof(UuidStruct), &data, JsonUuid)
+IMPLEMENT_AddValue(UuidStruct, sizeof(UuidStruct), &data, JsonUuid);
 
-    bool JsonImplementType<UuidStruct>::ConvertTo(
-        JsonValue const& jsonValue,
-        UuidStruct& value) throw()
+bool JsonImplementType<UuidStruct>::ConvertTo(
+    JsonValue const& jsonValue,
+    UuidStruct& value) throw()
 {
     bool success;
 

--- a/src/JsonBuilder.cpp
+++ b/src/JsonBuilder.cpp
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <jsonbuilder/JsonBuilder.h>
-
 #include <cassert>
 
+#include <jsonbuilder/JsonBuilder.h>
 
 #define StorageSize sizeof(JsonValue::StoragePod)
 #define DataMax 0xf0000000
@@ -463,6 +462,21 @@ JsonBuilder::const_iterator JsonBuilder::cend() const throw()
     return const_iterator(this, 0);
 }
 
+JsonBuilder::iterator JsonBuilder::root() throw()
+{
+    return end();
+}
+
+JsonBuilder::const_iterator JsonBuilder::root() const throw()
+{
+    return end();
+}
+
+JsonBuilder::const_iterator JsonBuilder::croot() const throw()
+{
+    return end();
+}
+
 JsonBuilder::size_type JsonBuilder::buffer_size() const throw()
 {
     return m_storage.size() * StorageSize;
@@ -777,7 +791,8 @@ void JsonBuilder::EnsureRootExists()
 {
     if (m_storage.empty())
     {
-        unsigned index = CreateValue(nonstd::string_view(), JsonObject, 0, nullptr);
+        unsigned index =
+            CreateValue(nonstd::string_view(), JsonObject, 0, nullptr);
         if (index != 0)
         {
             std::terminate();
@@ -812,8 +827,7 @@ JsonBuilder::Index JsonBuilder::CreateValue(
     unsigned const dataIndex = valueIndex + DATA_OFFSET(cchName);
     unsigned const newStorageSize =
         dataIndex + (cbData + StorageSize - 1) / StorageSize;
-    auto const pOldStorageData =
-        reinterpret_cast<char const*>(m_storage.data());
+    auto const pOldStorageData = reinterpret_cast<char const*>(m_storage.data());
 
     if (newStorageSize <= valueIndex)
     {
@@ -829,8 +843,7 @@ JsonBuilder::Index JsonBuilder::CreateValue(
     pValue->m_type = type;
 
     auto pNameData = reinterpret_cast<char const*>(name.data());
-    auto const pNewStorageData =
-        reinterpret_cast<char const*>(m_storage.data());
+    auto const pNewStorageData = reinterpret_cast<char const*>(m_storage.data());
     if (pOldStorageData != pNewStorageData && pOldStorageData < pNameData &&
         pNameData < pOldStorageData + (valueIndex * StorageSize))
     {
@@ -902,7 +915,7 @@ and i32) aren't perfectly optimal... But they're probably close enough.
         JsonBuilder& builder,                                      \
         bool front,                                                \
         JsonConstIterator const& itParent,                         \
-        nonstd::string_view const& name,                              \
+        nonstd::string_view const& name,                           \
         DataType const& data)                                      \
     {                                                              \
         return builder.AddValue(                                   \
@@ -918,10 +931,11 @@ and i32) aren't perfectly optimal... But they're probably close enough.
 
 #define IMPLEMENT_JsonImplementType(DataType, ValueType)          \
     IMPLEMENT_AddValue(DataType, sizeof(data), &data, ValueType)  \
-    IMPLEMENT_GetUnchecked(DataType, ValueType)                   \
+        IMPLEMENT_GetUnchecked(DataType, ValueType)               \
                                                                   \
-    bool JsonImplementType<DataType>::ConvertTo(                  \
-        JsonValue const& value, DataType& result) throw()         \
+            bool                                                  \
+            JsonImplementType<DataType>::ConvertTo(               \
+                JsonValue const& value, DataType& result) throw() \
     {                                                             \
         return ConvertTo##ValueType(value, result);               \
     }
@@ -969,11 +983,11 @@ bool JsonImplementType<bool>::ConvertTo(JsonValue const& value, bool& result) th
 
 IMPLEMENT_AddValue(bool, sizeof(data), &data, JsonBool)
 
-// JsonUInt
+    // JsonUInt
 
-bool JsonImplementType<unsigned long long>::ConvertTo(
-    JsonValue const& value,
-    unsigned long long& result) throw()
+    bool JsonImplementType<unsigned long long>::ConvertTo(
+        JsonValue const& value,
+        unsigned long long& result) throw()
 {
     static double const UnsignedHuge = 18446744073709551616.0;
 
@@ -1048,10 +1062,10 @@ static uint64_t GetUncheckedJsonUInt(JsonValue const& value)
 }
 
 IMPLEMENT_AddValue(unsigned long long, sizeof(data), &data, JsonUInt)
-IMPLEMENT_GetUnchecked(unsigned long long, JsonUInt)
+    IMPLEMENT_GetUnchecked(unsigned long long, JsonUInt)
 
-template<class T>
-static bool ConvertToJsonUInt(JsonValue const& value, T& result)
+        template<class T>
+        static bool ConvertToJsonUInt(JsonValue const& value, T& result)
 {
     unsigned long long implResult;
     bool success;
@@ -1070,15 +1084,15 @@ static bool ConvertToJsonUInt(JsonValue const& value, T& result)
 }
 
 IMPLEMENT_JsonImplementType(unsigned char, JsonUInt)
-IMPLEMENT_JsonImplementType(unsigned short, JsonUInt)
-IMPLEMENT_JsonImplementType(unsigned int, JsonUInt)
-IMPLEMENT_JsonImplementType(unsigned long, JsonUInt)
+    IMPLEMENT_JsonImplementType(unsigned short, JsonUInt)
+        IMPLEMENT_JsonImplementType(unsigned int, JsonUInt)
+            IMPLEMENT_JsonImplementType(unsigned long, JsonUInt)
 
-// JsonInt
+    // JsonInt
 
-bool JsonImplementType<signed long long>::ConvertTo(
-    JsonValue const& value,
-    signed long long& result) throw()
+    bool JsonImplementType<signed long long>::ConvertTo(
+        JsonValue const& value,
+        signed long long& result) throw()
 {
     static double const SignedHuge = 9223372036854775808.0;
 
@@ -1153,10 +1167,10 @@ static int64_t GetUncheckedJsonInt(JsonValue const& value)
 }
 
 IMPLEMENT_AddValue(signed long long, sizeof(data), &data, JsonInt)
-IMPLEMENT_GetUnchecked(signed long long, JsonInt)
+    IMPLEMENT_GetUnchecked(signed long long, JsonInt)
 
-template<class T>
-static bool ConvertToJsonInt(JsonValue const& value, T& result)
+        template<class T>
+        static bool ConvertToJsonInt(JsonValue const& value, T& result)
 {
     signed long long implResult;
     bool success;
@@ -1178,13 +1192,13 @@ static bool ConvertToJsonInt(JsonValue const& value, T& result)
 }
 
 IMPLEMENT_JsonImplementType(signed char, JsonInt)
-IMPLEMENT_JsonImplementType(signed short, JsonInt)
-IMPLEMENT_JsonImplementType(signed int, JsonInt)
-IMPLEMENT_JsonImplementType(signed long, JsonInt)
+    IMPLEMENT_JsonImplementType(signed short, JsonInt)
+        IMPLEMENT_JsonImplementType(signed int, JsonInt)
+            IMPLEMENT_JsonImplementType(signed long, JsonInt)
 
-// JsonFloat
+    // JsonFloat
 
-double JsonImplementType<double>::GetUnchecked(JsonValue const& value) throw()
+    double JsonImplementType<double>::GetUnchecked(JsonValue const& value) throw()
 {
     assert(value.Type() == JsonFloat);
     double result;
@@ -1245,8 +1259,8 @@ IMPLEMENT_AddValue(double, sizeof(data), &data, JsonFloat)
 #define GetUncheckedJsonFloat(value) \
     JsonImplementType<double>::GetUnchecked(value)
 
-template<class T>
-static bool ConvertToJsonFloat(JsonValue const& value, T& result)
+    template<class T>
+    static bool ConvertToJsonFloat(JsonValue const& value, T& result)
 {
     double implResult;
     bool success = JsonImplementType<double>::ConvertTo(value, implResult);
@@ -1256,24 +1270,24 @@ static bool ConvertToJsonFloat(JsonValue const& value, T& result)
 
 IMPLEMENT_JsonImplementType(float, JsonFloat)
 
-// JsonUtf8
+    // JsonUtf8
 
-JsonIterator JsonImplementType<char*>::AddValue(
-    JsonBuilder& builder,
-    bool front,
-    JsonConstIterator const& itParent,
-    nonstd::string_view const& name,
-    char const* psz)
+    JsonIterator JsonImplementType<char*>::AddValue(
+        JsonBuilder& builder,
+        bool front,
+        JsonConstIterator const& itParent,
+        nonstd::string_view const& name,
+        char const* psz)
 {
     return builder.AddValue(
         front, itParent, name, JsonUtf8, static_cast<unsigned>(strlen(psz)), psz);
 }
 
 IMPLEMENT_AddValue(char, sizeof(data), &data, JsonUtf8)
-IMPLEMENT_AddValue(std::string, data.size(), data.data(), JsonUtf8)
+    IMPLEMENT_AddValue(std::string, data.size(), data.data(), JsonUtf8)
 
-nonstd::string_view
-JsonImplementType<nonstd::string_view>::GetUnchecked(JsonValue const& value) throw()
+        nonstd::string_view JsonImplementType<nonstd::string_view>::GetUnchecked(
+            JsonValue const& value) throw()
 {
     assert(value.Type() == JsonUtf8);
     unsigned cb;
@@ -1377,9 +1391,9 @@ JsonImplementType<std::chrono::system_clock::time_point>::GetUnchecked(
 
 IMPLEMENT_AddValue(UuidStruct, sizeof(UuidStruct), &data, JsonUuid)
 
-bool JsonImplementType<UuidStruct>::ConvertTo(
-    JsonValue const& jsonValue,
-    UuidStruct& value) throw()
+    bool JsonImplementType<UuidStruct>::ConvertTo(
+        JsonValue const& jsonValue,
+        UuidStruct& value) throw()
 {
     bool success;
 

--- a/src/JsonRenderer.cpp
+++ b/src/JsonRenderer.cpp
@@ -243,7 +243,7 @@ void JsonRenderer::IndentSpaces(unsigned value) throw()
 
 nonstd::string_view JsonRenderer::Render(JsonBuilder const& builder)
 {
-    auto itRoot = builder.end();
+    auto itRoot = builder.root();
     m_renderBuffer.clear();
     m_indent = 0;
     RenderStructure(itRoot, true);

--- a/test/TestBuilder.cpp
+++ b/test/TestBuilder.cpp
@@ -4,7 +4,6 @@
 #include <catch2/catch.hpp>
 #include <jsonbuilder/JsonBuilder.h>
 
-
 using namespace jsonbuilder;
 
 TEST_CASE("JsonBuilder buffer reserve", "[builder]")
@@ -84,12 +83,12 @@ static void TestInputOutputScalar()
 
     JsonBuilder b;
 
-    b.push_back(b.end(), "", InputLimits::lowest());
-    b.push_back(b.end(), "", InputLimits::min());
-    b.push_back(b.end(), "", InputLimits::max());
-    b.push_back(b.end(), "", OutputLimits::lowest());
-    b.push_back(b.end(), "", OutputLimits::min());
-    b.push_back(b.end(), "", OutputLimits::max());
+    b.push_back(b.root(), "", InputLimits::lowest());
+    b.push_back(b.root(), "", InputLimits::min());
+    b.push_back(b.root(), "", InputLimits::max());
+    b.push_back(b.root(), "", OutputLimits::lowest());
+    b.push_back(b.root(), "", OutputLimits::min());
+    b.push_back(b.root(), "", OutputLimits::max());
 
     REQUIRE_NOTHROW(b.ValidateData());
 
@@ -192,37 +191,37 @@ TEST_CASE("JsonBuilder string push_back")
 
     SECTION("push_back nonstd::string_view")
     {
-        auto itr = b.push_back(b.end(), "", nonstd::string_view{ "ABCDE" });
+        auto itr = b.push_back(b.root(), "", nonstd::string_view{ "ABCDE" });
         REQUIRE(itr->GetUnchecked<nonstd::string_view>() == "ABCDE");
     }
 
     SECTION("push_back std::string")
     {
-        auto itr = b.push_back(b.end(), "", std::string{ "ABCDE" });
+        auto itr = b.push_back(b.root(), "", std::string{ "ABCDE" });
         REQUIRE(itr->GetUnchecked<nonstd::string_view>() == "ABCDE");
     }
 
     SECTION("push_back char")
     {
-        auto itr = b.push_back(b.end(), "", ' ');
+        auto itr = b.push_back(b.root(), "", ' ');
         REQUIRE(itr->GetUnchecked<nonstd::string_view>() == " ");
     }
 
     SECTION("push_back char*")
     {
-        auto itr = b.push_back(b.end(), "", const_cast<char*>("ABC"));
+        auto itr = b.push_back(b.root(), "", const_cast<char*>("ABC"));
         REQUIRE(itr->GetUnchecked<nonstd::string_view>() == "ABC");
     }
 
     SECTION("push_back const char*")
     {
-        auto itr = b.push_back(b.end(), "", static_cast<const char*>("DEF"));
+        auto itr = b.push_back(b.root(), "", static_cast<const char*>("DEF"));
         REQUIRE(itr->GetUnchecked<nonstd::string_view>() == "DEF");
     }
 
     SECTION("push_back const char[]")
     {
-        auto itr = b.push_back(b.end(), "", "HIJ");
+        auto itr = b.push_back(b.root(), "", "HIJ");
         REQUIRE(itr->GetUnchecked<nonstd::string_view>() == "HIJ");
     }
 }
@@ -232,7 +231,7 @@ TEST_CASE("JsonBuilder chrono push_back", "[builder]")
     auto now = std::chrono::system_clock::now();
 
     JsonBuilder b;
-    auto itr = b.push_back(b.end(), "CurrentTime", now);
+    auto itr = b.push_back(b.root(), "CurrentTime", now);
     auto retrieved = itr->GetUnchecked<std::chrono::system_clock::time_point>();
     REQUIRE(retrieved == now);
 }
@@ -243,7 +242,7 @@ TEST_CASE("JsonBuilder uuid push_back", "[builder]")
     uuid_generate(uuid.Data);
 
     JsonBuilder b;
-    auto itr = b.push_back(b.end(), "Uuid", uuid);
+    auto itr = b.push_back(b.root(), "Uuid", uuid);
 
     auto retrieved = itr->GetUnchecked<UuidStruct>();
     REQUIRE(uuid_compare(retrieved.Data, uuid.Data) == 0);
@@ -258,15 +257,15 @@ TEST_CASE("JsonBuilder find", "[builder]")
     REQUIRE(b.find("a1", "a2") == b.end());
 
     // Single object (a1)
-    auto itA1 = b.push_back(b.end(), "a1", JsonObject);
+    auto itA1 = b.push_back(b.root(), "a1", JsonObject);
     REQUIRE(b.find("a1") == itA1);
-    REQUIRE(b.find(b.end(), "a1") == itA1);
+    REQUIRE(b.find(b.root(), "a1") == itA1);
     REQUIRE(b.find("b1") == b.end());
-    REQUIRE(b.find(b.end(), "b1") == b.end());
+    REQUIRE(b.find(b.root(), "b1") == b.end());
     REQUIRE(b.find("a1", "a2") == b.end());
 
     // Second object b2, sibling of a1
-    auto itB1 = b.push_back(b.end(), "b1", JsonObject);
+    auto itB1 = b.push_back(b.root(), "b1", JsonObject);
     REQUIRE(b.find("a1") == itA1);
     REQUIRE(b.find("a1", "a2") == b.end());
     REQUIRE(b.find("b1") == itB1);
@@ -276,7 +275,7 @@ TEST_CASE("JsonBuilder find", "[builder]")
     auto itA1A2 = b.push_back(itA1, "a2", JsonObject);
     REQUIRE(b.find("a1") == itA1);
     REQUIRE(b.find("a1", "a2") == itA1A2);
-    REQUIRE(b.find(b.end(), "a1", "a2") == itA1A2);
+    REQUIRE(b.find(b.root(), "a1", "a2") == itA1A2);
     REQUIRE(b.find("a1", "a2", "a3") == b.end());
     REQUIRE(b.find("b1") == itB1);
     REQUIRE(b.find("c1") == b.end());
@@ -293,8 +292,8 @@ TEST_CASE("JsonBuilder find", "[builder]")
 TEST_CASE("JsonBuilder constructors", "[builder]")
 {
     JsonBuilder b;
-    b.push_back(b.end(), "aname", "ava");
-    b.push_back(b.end(), "bname", "bva");
+    b.push_back(b.root(), "aname", "ava");
+    b.push_back(b.root(), "bname", "bva");
     REQUIRE_NOTHROW(b.ValidateData());
 
     SECTION("Copy constructor")
@@ -329,8 +328,8 @@ TEST_CASE("JsonBuilder constructors", "[builder]")
 TEST_CASE("JsonBuilder erase", "[builder]")
 {
     JsonBuilder b;
-    b.push_back(b.end(), "aname", "ava");
-    b.push_back(b.end(), "bname", "bva");
+    b.push_back(b.root(), "aname", "ava");
+    b.push_back(b.root(), "bname", "bva");
     REQUIRE_NOTHROW(b.ValidateData());
 
     SECTION("erase a single child element")
@@ -338,7 +337,7 @@ TEST_CASE("JsonBuilder erase", "[builder]")
         auto itr = b.erase(b.begin());
         REQUIRE_NOTHROW(b.ValidateData());
         REQUIRE(itr == b.begin());
-        REQUIRE(b.count(b.end()) == 1);
+        REQUIRE(b.count(b.root()) == 1);
     }
 
     SECTION("erase all children")
@@ -365,7 +364,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("JsonNull")
     {
-        auto itr = b.push_back(b.end(), "FirstItem", JsonNull);
+        auto itr = b.push_back(b.root(), "FirstItem", JsonNull);
 
         REQUIRE(itr->IsNull());
         REQUIRE(!itr->ConvertTo(bval));
@@ -379,7 +378,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("false")
     {
-        auto itr = b.push_back(b.end(), "", false);
+        auto itr = b.push_back(b.root(), "", false);
 
         REQUIRE(itr->GetUnchecked<bool>() == false);
         REQUIRE((itr->ConvertTo(bval) && !bval));
@@ -393,7 +392,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("true")
     {
-        auto itr = b.push_back(b.end(), "", true);
+        auto itr = b.push_back(b.root(), "", true);
 
         REQUIRE(itr->GetUnchecked<bool>() == true);
         REQUIRE((itr->ConvertTo(bval) && bval));
@@ -407,7 +406,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("int64_t")
     {
-        auto itr = b.push_back(b.end(), "", 123);
+        auto itr = b.push_back(b.root(), "", 123);
 
         REQUIRE(itr->GetUnchecked<int64_t>() == 123);
         REQUIRE(!itr->ConvertTo(bval));
@@ -421,7 +420,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("uint64_t")
     {
-        auto itr = b.push_back(b.end(), "", 123u);
+        auto itr = b.push_back(b.root(), "", 123u);
 
         REQUIRE(itr->GetUnchecked<uint64_t>() == 123u);
         REQUIRE(!itr->ConvertTo(bval));
@@ -435,7 +434,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("double")
     {
-        auto itr = b.push_back(b.end(), "", 123.0);
+        auto itr = b.push_back(b.root(), "", 123.0);
 
         REQUIRE(itr->GetUnchecked<double>() == 123.0);
         REQUIRE(!itr->ConvertTo(bval));
@@ -449,7 +448,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("string")
     {
-        auto itr = b.push_back(b.end(), "", "ABC");
+        auto itr = b.push_back(b.root(), "", "ABC");
 
         REQUIRE(itr->GetUnchecked<nonstd::string_view>() == "ABC");
         REQUIRE(!itr->ConvertTo(bval));
@@ -463,7 +462,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("less than int64_t min as double")
     {
-        auto itr = b.push_back(b.end(), "", -9223372036854777856.0);
+        auto itr = b.push_back(b.root(), "", -9223372036854777856.0);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE((itr->ConvertTo(fval) && fval == -9223372036854777856.0));
@@ -481,7 +480,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
         // applied.
         constexpr int64_t c_int64min = (-9223372036854775807ll - 1);
 
-        auto itr = b.push_back(b.end(), "", c_int64min);
+        auto itr = b.push_back(b.root(), "", c_int64min);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE((itr->ConvertTo(fval) && fval == -9223372036854775808.0));
@@ -494,7 +493,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("-1")
     {
-        auto itr = b.push_back(b.end(), "", -1);
+        auto itr = b.push_back(b.root(), "", -1);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE((itr->ConvertTo(fval) && fval == -1.0));
@@ -507,7 +506,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("0")
     {
-        auto itr = b.push_back(b.end(), "", 0);
+        auto itr = b.push_back(b.root(), "", 0);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE((itr->ConvertTo(fval) && fval == 0.0));
@@ -520,7 +519,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("int64_t max")
     {
-        auto itr = b.push_back(b.end(), "", 9223372036854775807);
+        auto itr = b.push_back(b.root(), "", 9223372036854775807);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE((itr->ConvertTo(fval) && fval == 9223372036854775807.0));
@@ -533,7 +532,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("greater than int64_t max and less than uint64_t max")
     {
-        auto itr = b.push_back(b.end(), "", 9223372036854775808ull);
+        auto itr = b.push_back(b.root(), "", 9223372036854775808ull);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE((itr->ConvertTo(fval) && fval == 9223372036854775808.0));
@@ -546,7 +545,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("greater than int64_t max and less than uint64_t max as double")
     {
-        auto itr = b.push_back(b.end(), "", 9223372036854777856.0);
+        auto itr = b.push_back(b.root(), "", 9223372036854777856.0);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE((itr->ConvertTo(fval) && fval == 9223372036854777856.0));
@@ -559,7 +558,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("uint64_t max")
     {
-        auto itr = b.push_back(b.end(), "", 18446744073709551615ull);
+        auto itr = b.push_back(b.root(), "", 18446744073709551615ull);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE((itr->ConvertTo(fval) && fval == 18446744073709551615.0));
@@ -572,7 +571,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
 
     SECTION("greater than uint64_t max")
     {
-        auto itr = b.push_back(b.end(), "", 18446744073709551616.0);
+        auto itr = b.push_back(b.root(), "", 18446744073709551616.0);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE((itr->ConvertTo(fval) && fval == 18446744073709551615.0));
@@ -586,7 +585,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
     SECTION("time")
     {
         auto now = std::chrono::system_clock::now();
-        auto itr = b.push_back(b.end(), "", now);
+        auto itr = b.push_back(b.root(), "", now);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE(!itr->ConvertTo(fval));
@@ -602,7 +601,7 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
         UuidStruct uuid;
         uuid_generate(uuid.Data);
 
-        auto itr = b.push_back(b.end(), "", uuid);
+        auto itr = b.push_back(b.root(), "", uuid);
 
         REQUIRE(!itr->ConvertTo(bval));
         REQUIRE(!itr->ConvertTo(fval));
@@ -615,20 +614,3 @@ TEST_CASE("JsonBuilder conversions", "[builder]")
              0 == uuid_compare(uuidval.Data, uuid.Data)));
     }
 }
-// int main()
-// {
-//     JsonBuilder builder;
-//     builder.push_back(builder.end(), "field", 5l);
-//     builder.push_back(builder.end(), "String", "Grandes écoles");
-//     builder.push_back(
-//         builder.end(), "CurrentTime", std::chrono::system_clock::now());
-
-//     JsonRenderer renderer;
-//     renderer.Pretty(true);
-
-//     nonstd::string_view output = renderer.Render(builder);
-
-//     std::cout << output << std::endl;
-
-//     return 0;
-// }

--- a/test/TestRenderer.cpp
+++ b/test/TestRenderer.cpp
@@ -213,11 +213,11 @@ TEST_CASE("JsonRenderer full object", "[renderer]")
 {
     JsonBuilder b;
 
-    auto objItr = b.push_back(b.end(), "obj", JsonObject);
+    auto objItr = b.push_back(b.root(), "obj", JsonObject);
     b.push_back(objItr, "str", "strval");
     b.push_back(objItr, "str2", "str2val");
 
-    auto arrItr = b.push_back(b.end(), "arr", JsonArray);
+    auto arrItr = b.push_back(b.root(), "arr", JsonArray);
     b.push_back(arrItr, "useless", 1);
     b.push_back(arrItr, "useless2", 2);
 
@@ -234,7 +234,6 @@ TEST_CASE("JsonRenderer full object", "[renderer]")
 
     SECTION("Pretty renderer")
     {
-
         JsonRenderer renderer;
         renderer.Pretty(true);
         auto renderString = renderer.Render(b);


### PR DESCRIPTION
Using the end() method to get access to the root of the JsonBuilder is confusing, so this adds an aliased method called root().  We'll still use .end() to compare .find() results, but we'll use .root() for iteration and insertion with push_back.