### PR TITLE
Fix build issues in AOSP

### DIFF
--- a/include/jsonbuilder/JsonBuilder.h
+++ b/include/jsonbuilder/JsonBuilder.h
@@ -65,6 +65,7 @@ Error handling:
 #include <math.h>     // isfinite, sqrt
 #include <stdexcept>  // std::invalid_argument
 #include <string_view>
+#include <string>
 
 #include <uuid/uuid.h>
 

--- a/src/JsonBuilder.cpp
+++ b/src/JsonBuilder.cpp
@@ -1375,8 +1375,9 @@ JsonImplementType<std::chrono::system_clock::time_point>::GetUnchecked(
     if (jsonValue.DataSize() == 8)
     {
         int64_t nanosSinceEpoch = *static_cast<const int64_t*>(jsonValue.Data());
-        return std::chrono::system_clock::time_point{ std::chrono::nanoseconds{
-            nanosSinceEpoch } };
+        std::chrono::nanoseconds nanosAsType = std::chrono::nanoseconds{ nanosSinceEpoch };
+        std::chrono::system_clock::time_point timepointResult{ std::chrono::duration_cast<std::chrono::system_clock::duration>(nanosAsType) };
+        return timepointResult;
     }
     else
     {


### PR DESCRIPTION
Change-Id: I2ee44f64b49613327939629d5123cda5d5a675ed

Fixes two issues arising in AOSP:
1) Missing string include causes build failures
2) GetUnchecked for time_point assumes the system_clock has a nanosecond resolution