### PR TITLE
Add virtual destructor for JsonRenderer

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16,7 +16,6 @@ cc_library_static {
         "-Wall",
         "-Werror",
         "-Wno-implicit-fallthrough",
-        "-Wno-non-virtual-dtor", // TODO: Issue in JsonRenderer for missing virtual destructor
         "-fexceptions"
     ],
 

--- a/include/jsonbuilder/JsonRenderer.h
+++ b/include/jsonbuilder/JsonRenderer.h
@@ -56,6 +56,11 @@ class JsonRenderer
         unsigned indentSpaces = 2) throw();
 
     /*
+    Virtual destructor
+    */
+    virtual ~JsonRenderer() {}
+
+    /*
     Preallocates memory in the rendering buffer (increases capacity).
     */
     void Reserve(size_type cb);  // may throw bad_alloc, length_error


### PR DESCRIPTION
Change-Id: I3768063b8a14b8ccd90257beb550e46edbe93801

Fixes issue with Clang under Wall / Werror where JsonRenderer has a virtual method but no virtual destructor defined.