### PR TITLE
JsonBuilder - remove cross-platform barriers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,22 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.15)
 
 project(jsonbuilder VERSION 0.2)
 
-add_compile_options(-Wall -Wextra)
-
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
-find_package(uuid REQUIRED)
+if(WIN32)
+    add_compile_options(/W4 /WX /permissive-)
+else()
+    add_compile_options(
+        -Wall
+        -Wextra
+        -Wformat
+        -Wformat-security
+        -Werror=format-security
+        -Wstack-protector
+        -Werror=stack-protector)
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(-D_FORTIFY_SOURCE=2)
+    endif()
+endif()
 
 add_subdirectory(src)
 
@@ -13,6 +24,7 @@ add_subdirectory(src)
 if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     enable_testing()
 
+    list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
     if (EXISTS ${PROJECT_SOURCE_DIR}/external/Catch2/CMakeLists.txt)
         list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external/Catch2/contrib")
         add_subdirectory(external/Catch2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.15)
 
 add_library(jsonbuilder 
     JsonBuilder.cpp
+    JsonExceptions.cpp
     JsonRenderer.cpp
     PodVector.cpp)
 
@@ -10,7 +11,6 @@ target_include_directories(jsonbuilder
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(jsonbuilder PUBLIC uuid::uuid)
 target_compile_features(jsonbuilder PUBLIC cxx_std_17)
 
 set_property(TARGET jsonbuilder PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/JsonExceptions.cpp
+++ b/src/JsonExceptions.cpp
@@ -1,0 +1,16 @@
+#include <jsonbuilder/JsonBuilder.h>
+namespace jsonbuilder
+{
+    [[noreturn]] void _jsonbuilderDecl JsonThrowBadAlloc() noexcept(false)
+    {
+        throw std::bad_alloc();
+    }
+    [[noreturn]] void _jsonbuilderDecl JsonThrowLengthError(_In_z_ const char* what) noexcept(false)
+    {
+        throw std::length_error(what);
+    }
+    [[noreturn]] void _jsonbuilderDecl JsonThrowInvalidArgument(_In_z_ const char* what) noexcept(false)
+    {
+        throw std::invalid_argument(what);
+    }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,14 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.15)
 
-# Add source to this project's executable.
+set(LIB_TARGET_UUID)
+if(NOT WIN32)
+    find_package(uuid REQUIRED)
+    set(LIB_TARGET_UUID uuid)
+endif()
+
 add_executable(jsonbuilderTest CatchMain.cpp TestBuilder.cpp TestRenderer.cpp)
 target_compile_features(jsonbuilderTest PRIVATE cxx_std_17)
-target_link_libraries(jsonbuilderTest PRIVATE jsonbuilder Catch2::Catch2)
+target_link_libraries(jsonbuilderTest PRIVATE jsonbuilder Catch2::Catch2 ${LIB_TARGET_UUID})
 
 include(CTest)
 include(Catch)

--- a/test/TestRenderer.cpp
+++ b/test/TestRenderer.cpp
@@ -1,12 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cstring>
 #include <cstdio>
 #include <iterator>
 #include <type_traits>
 
 #include <catch2/catch.hpp>
 #include <jsonbuilder/JsonRenderer.h>
+
+#ifdef _WIN32
+#undef uuid_t
+using uuid_t = char unsigned[16];
+#else
+#include <uuid/uuid.h>
+#endif
 
 using namespace jsonbuilder;
 
@@ -173,20 +181,20 @@ using namespace std::string_view_literals;
 
 TEST_CASE("JsonRenderer JsonTime", "[renderer]")
 {
-    auto epoch = std::chrono::system_clock::from_time_t(0);
+    auto epoch = std::chrono::system_clock::from_time_t(2);
 
     char chars[39];
     memset(chars, 1, sizeof(chars));
 
     unsigned cch = JsonRenderTime(epoch, chars);
     REQUIRE(cch == strlen(chars));
-    REQUIRE(chars == "1970-01-01T00:00:00.0000000Z"sv);
+    REQUIRE(chars == "1970-01-01T00:00:02.0000000Z"sv);
 }
 
 TEST_CASE("JsonRenderer JsonUuid", "[renderer]")
 {
     uuid_t uuid;
-    for (int i = 0; i < 16; i++)
+    for (char unsigned i = 0; i < 16; i++)
     {
         uuid[i] = i;
     }


### PR DESCRIPTION
- Breaking: Remove some overloads that probably aren't a good idea.
  - Don't support AddValue of `char` (ASCII text). It's too easy to mix up with `unsigned char` (UINT8) or `signed char` (INT8), and it's not obvious that it is ASCII-only. Instead, use `std::string_view`.
  - Don't support AddValue of `std::string`. It forces a dependency on full-STL with very little benefit. Instead, use `std::string_view`.
- Fix building on WIN32.
- EnableZeroInitializeMemory() mode was broken. Fixed by removing "realloc" mode.
- Update minimum CMake because old version gives warnings on Windows.
- Update Catch2 because old version doesn't build on latest Linux.
- Minimize public header dependencies. Public header should only `#include` headers to satisfy itself (should not `#include` headers to satisfy the needs of any .cpp file) and should bend over backwards to minimize the things that it needs.
- Minimize implementation dependencies. For example, JsonBuilder doesn't need to depend on `uuid.h`. Only Linux tests need it, and that's just to make sure we interoperate correctly with `uuid_t`.
- Restore link-time customization of `throw` behavior.
- Restore SAL annotations. In Linux they are no-ops, but they're still there for documentation and for static checking of Windows builds.
- Fix ABI to implementation-independent.
  - Free functions specify calling convention.
  - `JsonTime` now specifies its frequency and epoch instead of using "whatever this STL's system_clock is using". (I picked FILETIME values.)
  - `JsonUuid` now specifies byte order. (Big-endian.)
  - JsonValue's bitfield no longer relies on implementation-defined behavior.
  - Add raw access to the ABI value for `JsonTime`.
- Fix up incorrect comments, fix some inefficient code in JsonRenderer.