### PR TITLE
JsonBuilder - convert string values to UTF-8

### DIFF
--- a/src/JsonBuilder.cpp
+++ b/src/JsonBuilder.cpp
@@ -115,6 +115,47 @@ Utf32ToUtf8(
     return iDest;
 }
 
+static unsigned
+SbcsToUtf8(
+    _Out_writes_to_(cchSrc * 3, return) char unsigned* pchDest,
+    _In_reads_(cchSrc) char const* pchSrc,
+    unsigned cchSrc,
+    _In_reads_(128) char16_t const* high128)
+    noexcept
+{
+    unsigned iDest = 0;
+    for (unsigned iSrc = 0; iSrc != cchSrc; iSrc += 1)
+    {
+        char unsigned const ch8 = pchSrc[iSrc];
+        if (ch8 < 0x80)
+        {
+            // ASCII character - don't use lookup table.
+            pchDest[iDest++] = static_cast<char unsigned>(ch8);
+            continue;
+        }
+
+        char16_t const ch = high128[ch8 - 0x80];
+        if (ch < 0x80)
+        {
+            pchDest[iDest++] = static_cast<char unsigned>(ch);
+        }
+        else if (ch < 0x800)
+        {
+            pchDest[iDest++] = static_cast<char unsigned>(0xC0 | (ch >> 6));
+            pchDest[iDest++] = static_cast<char unsigned>(0x80 | (ch & 0x3F));
+        }
+        else
+        {
+            // It could be in the surrogate range, but we don't care.
+            pchDest[iDest++] = static_cast<char unsigned>(0xE0 | (ch >> 12));
+            pchDest[iDest++] = static_cast<char unsigned>(0x80 | ((ch >> 6) & 0x3F));
+            pchDest[iDest++] = static_cast<char unsigned>(0x80 | (ch & 0x3F));
+        }
+    }
+
+    return iDest;
+}
+
 // JsonValue
 
 namespace jsonbuilder {
@@ -1175,7 +1216,36 @@ JsonBuilder::_newValueCommit(
 }
 
 JsonBuilder::iterator
-JsonBuilder::NewValueCommitAsUtfImpl(
+JsonBuilder::_newValueCommitSbcsAsUtf8(
+    JsonType type,
+    std::string_view sbcsData,
+    _In_reads_(128) char16_t const* high128)
+    noexcept(false)  // may throw bad_alloc, length_error
+{
+    auto constexpr WorstCaseMultiplier = 3u; // 1 UTF-16 code unit -> 3 UTF-8 code units.
+    if (sbcsData.size() > DataMax / WorstCaseMultiplier)
+    {
+        JsonThrowLengthError("JsonBuilder - cchData too large");
+    }
+
+    // Create node. Reserve worst-case size for data.
+    auto const cchSrc = static_cast<unsigned>(sbcsData.size());
+    auto const valueIt = _newValueCommit(type, cchSrc * WorstCaseMultiplier, nullptr);
+
+    // Copy data into node, converting to UTF-8.
+    auto& value = GetValue(valueIt.m_index);
+    auto const valueDataIndex = valueIt.m_index + DATA_OFFSET(value.m_cchName);
+    auto const cbDest = SbcsToUtf8(reinterpret_cast<unsigned char*>(&m_storage[valueDataIndex]), sbcsData.data(), cchSrc, high128);
+
+    // Shrink to fit actual data size.
+    value.m_cbData = cbDest; // Shrink
+    m_storage.resize(valueDataIndex + (cbDest + StorageSize - 1) / StorageSize); // Shrink
+
+    return valueIt;
+}
+
+JsonBuilder::iterator
+JsonBuilder::NewValueCommitUtfAsUtf8Impl(
     JsonType type,
     JsonInternal::JSON_SIZE_T cchData,
     _In_reads_(cchData) char const* pchDataUtf8)
@@ -1189,7 +1259,7 @@ JsonBuilder::NewValueCommitAsUtfImpl(
 }
 
 JsonBuilder::iterator
-JsonBuilder::NewValueCommitAsUtfImpl(
+JsonBuilder::NewValueCommitUtfAsUtf8Impl(
     JsonType type,
     JsonInternal::JSON_SIZE_T cchData,
     _In_reads_(cchData) char16_t const* pchDataUtf16)
@@ -1218,7 +1288,7 @@ JsonBuilder::NewValueCommitAsUtfImpl(
 }
 
 JsonBuilder::iterator
-JsonBuilder::NewValueCommitAsUtfImpl(
+JsonBuilder::NewValueCommitUtfAsUtf8Impl(
     JsonType type,
     JsonInternal::JSON_SIZE_T cchData,
     _In_reads_(cchData) char32_t const* pchDataUtf32)
@@ -1703,7 +1773,7 @@ JsonImplementType<char*>::AddValueCommit(
     JsonBuilder& builder,
     _In_z_ char const* psz)
 {
-    return builder._newValueCommitAsUtf8(JsonUtf8, psz);
+    return builder._newValueCommitUtfAsUtf8(JsonUtf8, psz);
 }
 
 JsonIterator
@@ -1711,7 +1781,7 @@ JsonImplementType<wchar_t*>::AddValueCommit(
     JsonBuilder& builder,
     _In_z_ wchar_t const* psz)
 {
-    return builder._newValueCommitAsUtf8(JsonUtf8, psz);
+    return builder._newValueCommitUtfAsUtf8(JsonUtf8, psz);
 }
 
 JsonIterator
@@ -1719,7 +1789,7 @@ JsonImplementType<char16_t*>::AddValueCommit(
     JsonBuilder& builder,
     _In_z_ char16_t const* psz)
 {
-    return builder._newValueCommitAsUtf8(JsonUtf8, psz);
+    return builder._newValueCommitUtfAsUtf8(JsonUtf8, psz);
 }
 
 JsonIterator
@@ -1727,7 +1797,7 @@ JsonImplementType<char32_t*>::AddValueCommit(
     JsonBuilder& builder,
     _In_z_ char32_t const* psz)
 {
-    return builder._newValueCommitAsUtf8(JsonUtf8, psz);
+    return builder._newValueCommitUtfAsUtf8(JsonUtf8, psz);
 }
 
 std::string_view
@@ -1764,7 +1834,7 @@ JsonImplementType<std::string_view>::AddValueCommit(
     JsonBuilder& builder,
     std::string_view data)
 {
-    return builder._newValueCommitAsUtf8(JsonUtf8, data);
+    return builder._newValueCommitUtfAsUtf8(JsonUtf8, data);
 }
 
 JsonIterator
@@ -1772,7 +1842,7 @@ JsonImplementType<std::wstring_view>::AddValueCommit(
     JsonBuilder& builder,
     std::wstring_view data)
 {
-    return builder._newValueCommitAsUtf8(JsonUtf8, data);
+    return builder._newValueCommitUtfAsUtf8(JsonUtf8, data);
 }
 
 JsonIterator
@@ -1780,7 +1850,7 @@ JsonImplementType<std::u16string_view>::AddValueCommit(
     JsonBuilder& builder,
     std::u16string_view data)
 {
-    return builder._newValueCommitAsUtf8(JsonUtf8, data);
+    return builder._newValueCommitUtfAsUtf8(JsonUtf8, data);
 }
 
 JsonIterator
@@ -1788,7 +1858,45 @@ JsonImplementType<std::u32string_view>::AddValueCommit(
     JsonBuilder& builder,
     std::u32string_view data)
 {
-    return builder._newValueCommitAsUtf8(JsonUtf8, data);
+    return builder._newValueCommitUtfAsUtf8(JsonUtf8, data);
+}
+
+JsonIterator
+JsonImplementType<latin1_view>::AddValueCommit(
+    JsonBuilder& builder,
+    latin1_view data)
+{
+    static constexpr char16_t High128[] = {
+        0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8A, 0x8B, 0x8C, 0x8D, 0x8E, 0x8F,
+        0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9A, 0x9B, 0x9C, 0x9D, 0x9E, 0x9F,
+        0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF,
+        0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE, 0xBF,
+        0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF,
+        0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF,
+        0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF,
+        0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
+    };
+    static_assert(sizeof(High128) == 128 * sizeof(High128[0]), "High128 size");
+    return builder._newValueCommitSbcsAsUtf8(JsonUtf8, data, High128);
+}
+
+JsonIterator
+JsonImplementType<cp1252_view>::AddValueCommit(
+    JsonBuilder& builder,
+    cp1252_view data)
+{
+    static constexpr char16_t High128[] = {
+        0x20AC, 0x0081, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021, 0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0x008D, 0x017D, 0x008F,
+        0x0090, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014, 0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0x009D, 0x017E, 0x0178,
+        0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF,
+        0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE, 0xBF,
+        0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF,
+        0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF,
+        0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF,
+        0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
+    };
+    static_assert(sizeof(High128) == 128 * sizeof(High128[0]), "High128 size");
+    return builder._newValueCommitSbcsAsUtf8(JsonUtf8, data, High128);
 }
 
 // JsonTime

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT WIN32)
 endif()
 
 add_executable(jsonbuilderTest CatchMain.cpp TestBuilder.cpp TestRenderer.cpp)
-target_compile_features(jsonbuilderTest PRIVATE cxx_std_17)
+target_compile_features(jsonbuilderTest PRIVATE cxx_std_20)
 target_link_libraries(jsonbuilderTest PRIVATE jsonbuilder Catch2::Catch2 ${LIB_TARGET_UUID})
 
 include(CTest)

--- a/test/TestBuilder.cpp
+++ b/test/TestBuilder.cpp
@@ -275,6 +275,18 @@ TEST_CASE("JsonBuilder string push_back")
         REQUIRE(itr->GetUnchecked<std::string_view>() == CHAR_USTRING());
     }
 
+    SECTION("push_back latin1_view")
+    {
+        auto itr = b.push_back(b.root(), "", latin1_view{ "ABCDE\x80\x90\x9F\xA0\xB0\xF0\xFF" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == reinterpret_cast<char const*>(u8"ABCDE\u0080\u0090\u009F\u00A0\u00B0\u00F0\u00FF"));
+    }
+
+    SECTION("push_back cp1252_view")
+    {
+        auto itr = b.push_back(b.root(), "", cp1252_view{ "ABCDE\x80\x90\x9F\xA0\xB0\xF0\xFF" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == reinterpret_cast<char const*>(u8"ABCDE\u20AC\u0090\u0178\u00A0\u00B0\u00F0\u00FF"));
+    }
+
     // wchar_t
 
     SECTION("push_back std::wstring_view")

--- a/test/TestBuilder.cpp
+++ b/test/TestBuilder.cpp
@@ -5,6 +5,9 @@
 #include <jsonbuilder/JsonBuilder.h>
 #include <string.h>
 
+#define USTRING(prefix) prefix ## "\u0024\u00A3\u0418\u0939\u20AC\uD55C\U00010348"
+#define CHAR_USTRING() reinterpret_cast<char const*>(USTRING(u8))
+
 #ifdef _WIN32
 using uuid_t = char unsigned[16];
 static void uuid_generate(uuid_t uuid)
@@ -101,8 +104,6 @@ static void TestInputOutputScalar()
 
     JsonBuilder b;
 
-#define USTRING(prefix) prefix ## "\u0024\u00A3\u0418\u0939\u20AC\uD55C\U00010348"
-
     b.push_back(b.root(), USTRING(u), InputLimits::lowest());
     b.push_back(b.root(), USTRING(U), InputLimits::min());
     b.push_back(b.root(), USTRING(L), InputLimits::max());
@@ -115,25 +116,25 @@ static void TestInputOutputScalar()
     InputType i;
 
     auto it = b.begin();
-    REQUIRE(it->Name() == USTRING(u8));
+    REQUIRE(it->Name() == CHAR_USTRING());
     REQUIRE(it->GetUnchecked<InputType>() == InputLimits::lowest());
     REQUIRE(it->ConvertTo(i));
     REQUIRE(i == InputLimits::lowest());
 
     ++it;
-    REQUIRE(it->Name() == USTRING(u8));
+    REQUIRE(it->Name() == CHAR_USTRING());
     REQUIRE(it->GetUnchecked<InputType>() == InputLimits::min());
     REQUIRE(it->ConvertTo(i));
     REQUIRE(i == InputLimits::min());
 
     ++it;
-    REQUIRE(it->Name() == USTRING(u8));
+    REQUIRE(it->Name() == CHAR_USTRING());
     REQUIRE(it->GetUnchecked<InputType>() == InputLimits::max());
     REQUIRE(it->ConvertTo(i));
     REQUIRE(i == InputLimits::max());
 
     ++it;
-    REQUIRE(it->Name() == USTRING(u8));
+    REQUIRE(it->Name() == CHAR_USTRING());
     REQUIRE(
         it->GetUnchecked<InputType>() ==
         static_cast<InputType>(OutputLimits::lowest()));
@@ -242,6 +243,8 @@ TEST_CASE("JsonBuilder string push_back")
 {
     JsonBuilder b;
 
+    // char
+
     SECTION("push_back std::string_view")
     {
         auto itr = b.push_back(b.root(), "", std::string_view{ "ABCDE" });
@@ -268,9 +271,150 @@ TEST_CASE("JsonBuilder string push_back")
 
     SECTION("push_back const char[]")
     {
-        auto itr = b.push_back(b.root(), "", "HIJ");
-        REQUIRE(itr->GetUnchecked<std::string_view>() == "HIJ");
+        auto itr = b.push_back(b.root(), "", CHAR_USTRING());
+        REQUIRE(itr->GetUnchecked<std::string_view>() == CHAR_USTRING());
     }
+
+    // wchar_t
+
+    SECTION("push_back std::wstring_view")
+    {
+        auto itr = b.push_back(b.root(), "", std::wstring_view{ L"ABCDE" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABCDE");
+    }
+
+    SECTION("push_back std::wstring")
+    {
+        auto itr = b.push_back<std::wstring_view>(b.root(), "", std::wstring{ L"ABCDE" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABCDE");
+    }
+
+    SECTION("push_back wchar_t*")
+    {
+        auto itr = b.push_back(b.root(), "", const_cast<wchar_t*>(L"ABC"));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABC");
+    }
+
+    SECTION("push_back const wchar_t*")
+    {
+        auto itr = b.push_back(b.root(), "", static_cast<const wchar_t*>(L"DEF"));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "DEF");
+    }
+
+    SECTION("push_back const wchar_t[]")
+    {
+        auto itr = b.push_back(b.root(), "", USTRING(L));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == CHAR_USTRING());
+    }
+
+    // char8_t
+
+#ifdef __cpp_lib_char8_t // C++20
+
+    SECTION("push_back std::u8string_view")
+    {
+        auto itr = b.push_back(b.root(), "", std::u8string_view{ u8"ABCDE" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABCDE");
+        REQUIRE(itr->GetUnchecked<std::u8string_view>() == u8"ABCDE");
+    }
+
+    SECTION("push_back std::u8string")
+    {
+        auto itr = b.push_back<std::u8string_view>(b.root(), "", std::u8string{ u8"ABCDE" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABCDE");
+        REQUIRE(itr->GetUnchecked<std::u8string_view>() == u8"ABCDE");
+    }
+
+    SECTION("push_back char8_t*")
+    {
+        auto itr = b.push_back(b.root(), "", const_cast<char8_t*>(u8"ABC"));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABC");
+        REQUIRE(itr->GetUnchecked<std::u8string_view>() == u8"ABC");
+    }
+
+    SECTION("push_back const char8_t*")
+    {
+        auto itr = b.push_back(b.root(), "", static_cast<const char8_t*>(u8"DEF"));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "DEF");
+        REQUIRE(itr->GetUnchecked<std::u8string_view>() == u8"DEF");
+    }
+
+#endif // __cpp_lib_char8_t
+
+    SECTION("push_back const char8_t[]")
+    {
+        auto itr = b.push_back(b.root(), "", USTRING(u8));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == CHAR_USTRING());
+#ifdef __cpp_lib_char8_t // C++20
+        REQUIRE(itr->GetUnchecked<std::u8string_view>() == USTRING(u8));
+#endif // __cpp_lib_char8_t
+    }
+
+    // char16_t
+
+    SECTION("push_back std::u16string_view")
+    {
+        auto itr = b.push_back(b.root(), "", std::u16string_view{ u"ABCDE" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABCDE");
+    }
+
+    SECTION("push_back std::u16string")
+    {
+        auto itr = b.push_back<std::u16string_view>(b.root(), "", std::u16string{ u"ABCDE" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABCDE");
+    }
+
+    SECTION("push_back char16_t*")
+    {
+        auto itr = b.push_back(b.root(), "", const_cast<char16_t*>(u"ABC"));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABC");
+    }
+
+    SECTION("push_back const char16_t*")
+    {
+        auto itr = b.push_back(b.root(), "", static_cast<const char16_t*>(u"DEF"));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "DEF");
+    }
+
+    SECTION("push_back const char16_t[]")
+    {
+        auto itr = b.push_back(b.root(), "", USTRING(u));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == CHAR_USTRING());
+    }
+
+    // char32_t
+
+    SECTION("push_back std::u32string_view")
+    {
+        auto itr = b.push_back(b.root(), "", std::u32string_view{ U"ABCDE" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABCDE");
+    }
+
+    SECTION("push_back std::u32string")
+    {
+        auto itr = b.push_back<std::u32string_view>(b.root(), "", std::u32string{ U"ABCDE" });
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABCDE");
+    }
+
+    SECTION("push_back char32_t*")
+    {
+        auto itr = b.push_back(b.root(), "", const_cast<char32_t*>(U"ABC"));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "ABC");
+    }
+
+    SECTION("push_back const char32_t*")
+    {
+        auto itr = b.push_back(b.root(), "", static_cast<const char32_t*>(U"DEF"));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == "DEF");
+    }
+
+    SECTION("push_back const char32_t[]")
+    {
+        auto itr = b.push_back(b.root(), "", USTRING(U));
+        REQUIRE(itr->GetUnchecked<std::string_view>() == CHAR_USTRING());
+    }
+
+    b.ValidateData();
 }
 
 TEST_CASE("JsonBuilder chrono push_back", "[builder]")


### PR DESCRIPTION
Add support for converting data from latin1, cp1252, or UTF-NN to UTF-8 when the data is added to the JsonBuilder, i.e. you can now `push_back` a latin1, cp1252, UTF-16 or UTF-32 string and it will be converted to UTF-8 as part of the `push_back` process.

- push_back and other "add" APIs now support strings/string_views of char, wchar_t, char8_t, char16_t, and char32_t. All of these are assumed to be UTF-NN (NN selected based on element size).
- push_back and other "add" APIs now support `latin1_view` and `cp1252_view`.
- GetUnchecked and other "get" APIs only support string_view and u8string_view.

Alternative design would be to add new data types for JsonUtf16 and JsonUtf32, and then store the string in the JsonBuilder using its original encoding. This seems problematic -- anything reading string values would need to check the string's encoding and have separate code paths for each of the 3 encodings.