### PR TITLE
Adjusting the project to build with `catch` version 3+.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
         list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external/Catch2/contrib")
         add_subdirectory(external/Catch2)
     else ()
-        find_package(Catch2 REQUIRED)
+        find_package(Catch2 3 REQUIRED)
     endif ()
 
     add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,9 +6,9 @@ if(NOT WIN32)
     set(LIB_TARGET_UUID uuid)
 endif()
 
-add_executable(jsonbuilderTest CatchMain.cpp TestBuilder.cpp TestRenderer.cpp)
+add_executable(jsonbuilderTest TestBuilder.cpp TestRenderer.cpp)
 target_compile_features(jsonbuilderTest PRIVATE cxx_std_20)
-target_link_libraries(jsonbuilderTest PRIVATE jsonbuilder Catch2::Catch2 ${LIB_TARGET_UUID})
+target_link_libraries(jsonbuilderTest PRIVATE jsonbuilder Catch2::Catch2WithMain ${LIB_TARGET_UUID})
 
 include(CTest)
 include(Catch)

--- a/test/CatchMain.cpp
+++ b/test/CatchMain.cpp
@@ -1,5 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>

--- a/test/TestBuilder.cpp
+++ b/test/TestBuilder.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <jsonbuilder/JsonBuilder.h>
 #include <string.h>
 

--- a/test/TestRenderer.cpp
+++ b/test/TestRenderer.cpp
@@ -6,7 +6,7 @@
 #include <iterator>
 #include <type_traits>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <jsonbuilder/JsonRenderer.h>
 
 #ifdef _WIN32


### PR DESCRIPTION
Related to #29.

This is a sample PR showing the adjustments, which allowed to build `jsonbuilder` with version 3 of the `catch` project. The only intention of this PR is to help visualize what switching to `catch` 3+ may require, if you desire to make it possible.

Changes done by following `catch` documentation:
- [Using `catch` default implementation of `main`](https://github.com/catchorg/Catch2/blob/devel/docs/own-main.md).
- [3.0.0-preview4 release notes explaining the break-up of `catch.hpp` into smaller headers](https://github.com/catchorg/Catch2/releases/tag/v3.0.0-preview4).